### PR TITLE
Add option to skip check for updates

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-var updateNotifier = require('update-notifier');
 var meow = require('meow');
 var del = require('del');
 
@@ -11,6 +10,7 @@ var cli = meow([
 	'Options',
 	'  -f, --force    Allow deleting the current working directory and outside',
 	'  -d, --dry-run  List what would be deleted instead of deleting',
+	'  --skip-update  Do not check after updated version of this package',
 	'',
 	'Examples',
 	'  $ del unicorn.png rainbow.png',
@@ -19,7 +19,8 @@ var cli = meow([
 	string: ['_'],
 	boolean: [
 		'force',
-		'dry-run'
+		'dry-run',
+		'skip-update'
 	],
 	alias: {
 		f: 'force',
@@ -27,7 +28,11 @@ var cli = meow([
 	}
 });
 
-updateNotifier({pkg: cli.pkg}).notify();
+if (!cli.flags.skipUpdate) {
+	var updateNotifier = require('update-notifier');
+
+	updateNotifier({pkg: cli.pkg}).notify();
+}
 
 if (cli.input.length === 0) {
 	console.error('Specify at least one path');


### PR DESCRIPTION
`del` gives us an EPERM on our CI, would like to skip this check which makes the error go away

```
error   31-Mar-2016 14:15:50    Error: EPERM: operation not permitted, rename 'C:\Windows\system32\config\systemprofile\.config\configstore\update-notifier-del-cli.json.1874881583' -> 'C:\Windows\system32\config\systemprofile\.config\configstore\update-notifier-del-cli.json'
error   31-Mar-2016 14:15:50        at Error (native)
error   31-Mar-2016 14:15:50        at Object.fs.renameSync (fs.js:681:18)
error   31-Mar-2016 14:15:50        at Function.writeFileSync [as sync] (D:\Bamboo\bamboo-home\xml-data\build-dir\SON-FRON-JOB1\code\node_modules\write-file-atomic\index.js:39:8)
error   31-Mar-2016 14:15:50        at Object.create.all.set (D:\Bamboo\bamboo-home\xml-data\build-dir\SON-FRON-JOB1\code\node_modules\configstore\index.js:63:21)
error   31-Mar-2016 14:15:50        at Object.Configstore (D:\Bamboo\bamboo-home\xml-data\build-dir\SON-FRON-JOB1\code\node_modules\configstore\index.js:28:11)
error   31-Mar-2016 14:15:50        at new UpdateNotifier (D:\Bamboo\bamboo-home\xml-data\build-dir\SON-FRON-JOB1\code\node_modules\update-notifier\index.js:34:17)
error   31-Mar-2016 14:15:50        at module.exports (D:\Bamboo\bamboo-home\xml-data\build-dir\SON-FRON-JOB1\code\node_modules\update-notifier\index.js:108:23)
error   31-Mar-2016 14:15:50        at Object.<anonymous> (D:\Bamboo\bamboo-home\xml-data\build-dir\SON-FRON-JOB1\code\node_modules\del-cli\cli.js:30:1)
error   31-Mar-2016 14:15:50        at Module._compile (module.js:435:26)
error   31-Mar-2016 14:15:50        at Object.Module._extensions..js (module.js:442:10)
```
