### PR TITLE
Update meow from v5 to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	],
 	"dependencies": {
 		"del": "^5.1.0",
-		"meow": "^5.0.0"
+		"meow": "^6.1.1"
 	},
 	"devDependencies": {
 		"ava": "^2.3.0",


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/del-cli/issues/15

- meow v6.1.1 updated yargs-parser to v18.1.2, which contains a fix for
a Prototype Pollution vulnerability reported in npm audit.

# Testing

## `npm run-script test` output
```
> del-cli@3.0.0 test /Users/kueng/work/sandboxes/del-cli
> xo && ava



  1 test passed
```

## `npm audit --production` output
Using npm v6.14.5

```
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities
 in 147 scanned packages
```